### PR TITLE
go-1.11.1 fixes

### DIFF
--- a/mdns.go
+++ b/mdns.go
@@ -480,12 +480,14 @@ func (s *MDNS) ScanInterfaces() (string, error) {
 			}
 			continue
 		}
-		if err := SetMulticastTTL(conn, newm.ipver, 255); err != nil {
+		conn, err = SetMulticastTTL(conn, newm.ipver, 255)
+		if err != nil {
 			if s.logLevel >= 1 {
 				log.Printf("SetMulticastTTL %s: %v\n", newm, err)
 			}
 		}
-		if err := SetMulticastLoopback(conn, newm.ipver, true); err != nil {
+		conn, err = SetMulticastLoopback(conn, newm.ipver, true)
+		if err != nil {
 			if s.logLevel >= 1 {
 				log.Printf("SetMulticastLoopback %s: %v\n", newm, err)
 			}
@@ -521,6 +523,7 @@ func (s *MDNS) udpListener(ifc *multicastIfc) {
 
 	b := make([]byte, 2048)
 	for ifc.run() && s.run() {
+		ifc.conn.SetDeadline(time.Now().Add(time.Second))
 		n, a, err := ifc.conn.ReadFromUDP(b)
 		if err != nil {
 			if s.logLevel >= 1 {

--- a/mdns_test.go
+++ b/mdns_test.go
@@ -28,7 +28,7 @@ type instance struct {
 func createInstance(service string, inst instance) *MDNS {
 	s, err := NewMDNS(inst.host, "224.0.0.254:9999", "[FF02::FF]:9998", true, *logLevelFlag)
 	if err != nil {
-		log.Fatal("can't translate address: %v", err)
+		log.Fatalf("can't translate address: %v", err)
 	}
 	s.AddService(service, inst.host, inst.port, inst.txt...)
 	return s
@@ -84,7 +84,7 @@ func checkDiscovered(host string, discovered []ServiceInstance, instances ...ins
 			return fmt.Errorf("%s didn't find SRV %s:%d", host, hostFQDN(inst.host), inst.port)
 		}
 		if !foundtxt[i] {
-			return fmt.Errorf("%s didn't find TXT %s:%d", host, inst.txt)
+			return fmt.Errorf("%s didn't find TXT %s:%d", host, inst.txt, inst.port)
 		}
 	}
 	return nil


### PR DESCRIPTION
Fixes a bug in how setsockopt was being implemented. See the comments in ipaux.go.